### PR TITLE
add has_intercept option to linear_scaling models

### DIFF
--- a/caliber/binary_classification/linear_scaling/base.py
+++ b/caliber/binary_classification/linear_scaling/base.py
@@ -1,4 +1,5 @@
 import abc
+from typing import Callable, Optional
 
 import numpy as np
 from scipy.special import expit, logit
@@ -7,6 +8,18 @@ from caliber.binary_classification.base import CustomBinaryClassificationModel
 
 
 class CustomBinaryClassificationLinearScaling(CustomBinaryClassificationModel, abc.ABC):
-    @staticmethod
-    def _predict_proba(params: np.ndarray, probs: np.ndarray) -> np.ndarray:
-        return expit(params[0] + params[1] * logit(probs))
+    def __init__(
+        self,
+        loss_fn: Callable[[np.ndarray, np.ndarray], float],
+        minimize_options: Optional[dict] = None,
+        has_intercept: bool = True,
+    ):
+        self._has_intercept = has_intercept
+        super().__init__(loss_fn, minimize_options)
+
+    def _predict_proba(self, params: np.ndarray, probs: np.ndarray) -> np.ndarray:
+        return (
+            expit(params[0] + params[1] * logit(probs))
+            if self._has_intercept
+            else expit(params * logit(probs))
+        )

--- a/caliber/binary_classification/linear_scaling/brute_fit_mixin_linear_scaling.py
+++ b/caliber/binary_classification/linear_scaling/brute_fit_mixin_linear_scaling.py
@@ -6,9 +6,8 @@ from caliber.binary_classification.base_brute_fit_mixin import (
 
 
 class BinaryClassificationLinearScalingBruteFitMixin(BinaryClassificationBruteFitMixin):
-    @staticmethod
-    def _get_ranges() -> List[Tuple]:
-        return [(-2, 2), (-2, 2)]
+    def _get_ranges(self) -> List[Tuple]:
+        return [(-2, 2), (0, 4)] if self._has_intercept else [(0, 4)]
 
     @staticmethod
     def _get_Ns() -> int:

--- a/caliber/binary_classification/linear_scaling/calibration/asce_linear_scaling.py
+++ b/caliber/binary_classification/linear_scaling/calibration/asce_linear_scaling.py
@@ -13,7 +13,11 @@ class ASCEBinaryClassificationLinearScaling(
     BinaryClassificationLinearScalingBruteFitMixin,
     CustomCalibrationBinaryClassificationLinearScaling,
 ):
-    def __init__(self, minimize_options: Optional[dict] = None):
+    def __init__(
+        self, minimize_options: Optional[dict] = None, has_intercept: bool = True
+    ):
         super().__init__(
-            loss_fn=average_squared_calibration_error, minimize_options=minimize_options
+            loss_fn=average_squared_calibration_error,
+            minimize_options=minimize_options,
+            has_intercept=has_intercept,
         )

--- a/caliber/binary_classification/linear_scaling/calibration/base.py
+++ b/caliber/binary_classification/linear_scaling/calibration/base.py
@@ -15,8 +15,9 @@ class CustomCalibrationBinaryClassificationLinearScaling(
         self,
         loss_fn: Callable[[np.ndarray, np.ndarray], float],
         minimize_options: Optional[dict] = None,
+        has_intercept: bool = True,
     ):
-        super().__init__(loss_fn, minimize_options)
+        super().__init__(loss_fn, minimize_options, has_intercept)
 
     def _get_output_for_loss(self, params: np.ndarray, probs: np.ndarray) -> np.ndarray:
         return self._predict_proba(params, probs)

--- a/caliber/binary_classification/linear_scaling/calibration/brier_linear_scaling.py
+++ b/caliber/binary_classification/linear_scaling/calibration/brier_linear_scaling.py
@@ -14,5 +14,11 @@ class BrierBinaryClassificationLinearScaling(
     BinaryClassificationLinearScalingSmoothFitMixin,
     CustomCalibrationBinaryClassificationLinearScaling,
 ):
-    def __init__(self, minimize_options: Optional[dict] = None):
-        super().__init__(loss_fn=brier_score_loss, minimize_options=minimize_options)
+    def __init__(
+        self, minimize_options: Optional[dict] = None, has_intercept: bool = True
+    ):
+        super().__init__(
+            loss_fn=brier_score_loss,
+            minimize_options=minimize_options,
+            has_intercept=has_intercept,
+        )

--- a/caliber/binary_classification/linear_scaling/calibration/cross_entropy_linear_scaling.py
+++ b/caliber/binary_classification/linear_scaling/calibration/cross_entropy_linear_scaling.py
@@ -14,5 +14,11 @@ class CrossEntropyBinaryClassificationLinearScaling(
     BinaryClassificationLinearScalingSmoothFitMixin,
     CustomCalibrationBinaryClassificationLinearScaling,
 ):
-    def __init__(self, minimize_options: Optional[dict] = None):
-        super().__init__(loss_fn=log_loss, minimize_options=minimize_options)
+    def __init__(
+        self, minimize_options: Optional[dict] = None, has_intercept: bool = True
+    ):
+        super().__init__(
+            loss_fn=log_loss,
+            minimize_options=minimize_options,
+            has_intercept=has_intercept,
+        )

--- a/caliber/binary_classification/linear_scaling/calibration/ece_linear_scaling.py
+++ b/caliber/binary_classification/linear_scaling/calibration/ece_linear_scaling.py
@@ -13,7 +13,11 @@ class ECEBinaryClassificationLinearScaling(
     BinaryClassificationLinearScalingBruteFitMixin,
     CustomCalibrationBinaryClassificationLinearScaling,
 ):
-    def __init__(self, minimize_options: Optional[dict] = None):
+    def __init__(
+        self, minimize_options: Optional[dict] = None, has_intercept: bool = True
+    ):
         super().__init__(
-            loss_fn=expected_calibration_error, minimize_options=minimize_options
+            loss_fn=expected_calibration_error,
+            minimize_options=minimize_options,
+            has_intercept=has_intercept,
         )

--- a/caliber/binary_classification/linear_scaling/performance/bal_acc_linear_scaling.py
+++ b/caliber/binary_classification/linear_scaling/performance/bal_acc_linear_scaling.py
@@ -10,11 +10,17 @@ from caliber.binary_classification.linear_scaling.performance.base import (
 class BalancedAccuracyBinaryClassificationLinearScaling(
     CustomPerformanceBinaryClassificationLinearScaling
 ):
-    def __init__(self, threshold: float, minimize_options: Optional[dict] = None):
+    def __init__(
+        self,
+        threshold: float,
+        minimize_options: Optional[dict] = None,
+        has_intercept: bool = True,
+    ):
         super().__init__(
             loss_fn=balanced_accuracy_loss_fn,
             threshold=threshold,
             minimize_options=minimize_options,
+            has_intercept=has_intercept,
         )
 
 

--- a/caliber/binary_classification/linear_scaling/performance/base.py
+++ b/caliber/binary_classification/linear_scaling/performance/base.py
@@ -19,8 +19,9 @@ class CustomPerformanceBinaryClassificationLinearScaling(
         loss_fn: Callable[[np.ndarray, np.ndarray], float],
         threshold: float,
         minimize_options: Optional[dict] = None,
+        has_intercept: bool = True,
     ):
-        super().__init__(loss_fn, minimize_options)
+        super().__init__(loss_fn, minimize_options, has_intercept)
         self._threshold = threshold
 
     def _get_output_for_loss(self, params: np.ndarray, probs: np.ndarray) -> np.ndarray:

--- a/caliber/binary_classification/linear_scaling/performance/f1_linear_scaling.py
+++ b/caliber/binary_classification/linear_scaling/performance/f1_linear_scaling.py
@@ -10,22 +10,34 @@ from caliber.binary_classification.linear_scaling.performance.base import (
 class PositiveF1BinaryClassificationLinearScaling(
     CustomPerformanceBinaryClassificationLinearScaling
 ):
-    def __init__(self, threshold: float, minimize_options: Optional[dict] = None):
+    def __init__(
+        self,
+        threshold: float,
+        minimize_options: Optional[dict] = None,
+        has_intercept: bool = True,
+    ):
         super().__init__(
             loss_fn=pos_f1_loss_fn,
             threshold=threshold,
             minimize_options=minimize_options,
+            has_intercept=has_intercept,
         )
 
 
 class NegativeF1BinaryClassificationLinearScaling(
     CustomPerformanceBinaryClassificationLinearScaling
 ):
-    def __init__(self, threshold: float, minimize_options: Optional[dict] = None):
+    def __init__(
+        self,
+        threshold: float,
+        minimize_options: Optional[dict] = None,
+        has_intercept: bool = True,
+    ):
         super().__init__(
             loss_fn=neg_f1_loss_fn,
             threshold=threshold,
             minimize_options=minimize_options,
+            has_intercept=has_intercept,
         )
 
 

--- a/caliber/binary_classification/linear_scaling/performance/positive_negative_rates_linear_scaling.py
+++ b/caliber/binary_classification/linear_scaling/performance/positive_negative_rates_linear_scaling.py
@@ -10,11 +10,17 @@ from caliber.binary_classification.linear_scaling.performance.base import (
 class PositiveNegativeRatesBinaryClassificationLinearScaling(
     CustomPerformanceBinaryClassificationLinearScaling
 ):
-    def __init__(self, threshold: float, minimize_options: Optional[dict] = None):
+    def __init__(
+        self,
+        threshold: float,
+        minimize_options: Optional[dict] = None,
+        has_intercept: bool = True,
+    ):
         super().__init__(
             loss_fn=true_positive_negative_rates_loss_fn,
             threshold=threshold,
             minimize_options=minimize_options,
+            has_intercept=has_intercept,
         )
 
 

--- a/caliber/binary_classification/linear_scaling/performance/precision_fixed_recall.py
+++ b/caliber/binary_classification/linear_scaling/performance/precision_fixed_recall.py
@@ -10,11 +10,17 @@ from caliber.binary_classification.linear_scaling.performance.base import (
 class PrecisionFixedRecallBinaryClassificationLinearScaling(
     CustomPerformanceBinaryClassificationLinearScaling
 ):
-    def __init__(self, threshold: float, minimize_options: Optional[dict] = None):
+    def __init__(
+        self,
+        threshold: float,
+        minimize_options: Optional[dict] = None,
+        has_intercept: bool = True,
+    ):
         super().__init__(
             loss_fn=precision_fixed_recall,
             threshold=threshold,
             minimize_options=minimize_options,
+            has_intercept=has_intercept,
         )
 
 

--- a/caliber/binary_classification/linear_scaling/performance/predictive_values_linear_scaling.py
+++ b/caliber/binary_classification/linear_scaling/performance/predictive_values_linear_scaling.py
@@ -10,11 +10,17 @@ from caliber.binary_classification.linear_scaling.performance.base import (
 class PredictiveValuesBinaryClassificationLinearScaling(
     CustomPerformanceBinaryClassificationLinearScaling
 ):
-    def __init__(self, threshold: float, minimize_options: Optional[dict] = None):
+    def __init__(
+        self,
+        threshold: float,
+        minimize_options: Optional[dict] = None,
+        has_intercept: bool = True,
+    ):
         super().__init__(
             loss_fn=predictive_values_loss_fn,
             threshold=threshold,
             minimize_options=minimize_options,
+            has_intercept=has_intercept,
         )
 
 

--- a/caliber/binary_classification/linear_scaling/performance/recall_fixed_precision.py
+++ b/caliber/binary_classification/linear_scaling/performance/recall_fixed_precision.py
@@ -10,11 +10,17 @@ from caliber.binary_classification.linear_scaling.performance.base import (
 class RecallFixedPrecisionBinaryClassificationLinearScaling(
     CustomPerformanceBinaryClassificationLinearScaling
 ):
-    def __init__(self, threshold: float, minimize_options: Optional[dict] = None):
+    def __init__(
+        self,
+        threshold: float,
+        minimize_options: Optional[dict] = None,
+        has_intercept: bool = True,
+    ):
         super().__init__(
             loss_fn=precision_fixed_recall,
             threshold=threshold,
             minimize_options=minimize_options,
+            has_intercept=has_intercept,
         )
 
 

--- a/caliber/binary_classification/linear_scaling/performance/righteousness_linear_scaling.py
+++ b/caliber/binary_classification/linear_scaling/performance/righteousness_linear_scaling.py
@@ -10,11 +10,17 @@ from caliber.binary_classification.linear_scaling.performance.base import (
 class RighteousnessBinaryClassificationLinearScaling(
     CustomPerformanceBinaryClassificationLinearScaling
 ):
-    def __init__(self, threshold: float, minimize_options: Optional[dict] = None):
+    def __init__(
+        self,
+        threshold: float,
+        minimize_options: Optional[dict] = None,
+        has_intercept: bool = True,
+    ):
         super().__init__(
             loss_fn=righteousness_loss_fn,
             threshold=threshold,
             minimize_options=minimize_options,
+            has_intercept=has_intercept,
         )
 
 

--- a/caliber/binary_classification/linear_scaling/smooth_fit_mixin_linear_scaling.py
+++ b/caliber/binary_classification/linear_scaling/smooth_fit_mixin_linear_scaling.py
@@ -8,6 +8,5 @@ from caliber.binary_classification.base_smooth_fit_mixin import (
 class BinaryClassificationLinearScalingSmoothFitMixin(
     BinaryClassificationSmoothFitMixin
 ):
-    @staticmethod
-    def _get_x0() -> np.ndarray:
-        return np.array([0.0, 1.0])
+    def _get_x0(self) -> np.ndarray:
+        return np.array([0.0, 1.0]) if self._has_intercept else np.array(1.0)


### PR DESCRIPTION
By setting `has_intercept` to False, effectively add a version of temperature scaling.