### PR TITLE
Add propensity ratio estimation model

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # Select the Python versions to test against
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
     steps:
       - name: Check out the code
         uses: actions/checkout@v3

--- a/caliber/__init__.py
+++ b/caliber/__init__.py
@@ -106,6 +106,7 @@ from caliber.multiclass_classification.ood.kolmogorov_interpolant import (
     KolmogorovInterpolantMulticlassClassificationModel,
 )
 from caliber.ood.mahalanobis import MahalanobisBinaryClassificationModel
+from caliber.ood.propensity_score import PropensityScoreEstimationModel
 from caliber.regression.binning.iterative.mean import (
     IterativeBinningMeanRegressionModel,
 )

--- a/caliber/ood/propensity_score.py
+++ b/caliber/ood/propensity_score.py
@@ -9,11 +9,27 @@ class PropensityScoreEstimationModel:
     def __init__(
         self,
         binary_classification_estimation_model: AbstractBinaryClassificationModel = XGBClassifier(objective='binary:logistic'),
-        binary_classification_calibration_model: AbstractBinaryClassificationModel = BetaBinaryClassificationModel(),
+        binary_classification_calibration_model: AbstractBinaryClassificationModel | None = BetaBinaryClassificationModel(),
         calib_frac: float = 0.5,
         clip_range: tuple[float, float] = (0.05, 0.95),
         seed: int = 0,
     ) -> None:
+        """
+        A propensity score estimation model. Given inputs from a source and a target distribution, 
+        and targets describing which distributions they belong to,
+        the model fits and then calibrates the probability that the input belongs to the distribution with target label equal 1.
+        Finally, it predicts the propensity score as an odds ratio, clipped to make sure it does not explode.
+        
+        Args:
+            binary_classification_estimation_model (_type_, optional): A binary classification model to classify inputs to source and 
+            target distributions. The model needs to include a `fit` and a `predict_proba` methods, with analogous signature as in 
+            standard Scikit-Learn binary classification models. Defaults to XGBClassifier(objective='binary:logistic').
+            binary_classification_calibration_model (AbstractBinaryClassificationModel | None, optional): A binary classification model 
+            to calibrate the probability returned by the estimation model. Defaults to BetaBinaryClassificationModel().
+            calib_frac (float, optional): The fraction of the data reserved for calibration. Defaults to 0.5.
+            clip_range (tuple[float, float], optional): The range to clip the propensity score within. Defaults to (0.05, 0.95).
+            seed (int, optional): a random seed. Defaults to 0.
+        """
         self._binary_classification_estimation_model = binary_classification_estimation_model
         self._binary_classification_calibration_model = binary_classification_calibration_model
         self._calib_frac = calib_frac
@@ -21,23 +37,43 @@ class PropensityScoreEstimationModel:
         self._rng = np.random.default_rng(seed)
         
     def fit(self, X: NDArray[np.float64], y: NDArray[np.int64]) -> None:
-        size = len(X)
-        train_size = int(size * (1 - self._calib_frac))
-        perm = self._rng.choice(size, size, replace=False)
-        train_perm, calib_perm = perm[:train_size], perm[train_size:]
-        X_train, X_calib = X[train_perm], X[calib_perm]
-        y_train, y_calib = y[train_perm], y[calib_perm] 
+        """
+        Fits the propensity score model.
         
-        self._binary_classification_estimation_model.fit(X_train, y_train)
-        p_calib = self._binary_classification_estimation_model.predict_proba(X_calib)
-        p_calib = self._reshape_proba(p_calib)
-        
-        self._binary_classification_calibration_model.fit(p_calib, y_calib)
+        Args:
+            X (NDArray[np.float64]): Inputs from source and target distributions.
+            y (NDArray[np.int64]): Binary targets describing which distribution an input belongs to.
+        """
+        if self._binary_classification_calibration_model is not None:
+            size = len(X)
+            train_size = int(size * (1 - self._calib_frac))
+            perm = self._rng.choice(size, size, replace=False)
+            train_perm, calib_perm = perm[:train_size], perm[train_size:]
+            X_train, X_calib = X[train_perm], X[calib_perm]
+            y_train, y_calib = y[train_perm], y[calib_perm] 
+            
+            self._binary_classification_estimation_model.fit(X_train, y_train)
+            p_calib = self._binary_classification_estimation_model.predict_proba(X_calib)
+            p_calib = self._reshape_proba(p_calib)
+            
+            self._binary_classification_calibration_model.fit(p_calib, y_calib)
+        else:
+            self._binary_classification_estimation_model.fit(X, y)
         
     def predict(self, X: NDArray[np.float64]) -> NDArray[np.float64]:
+        """
+        Predicts the propensity score.
+        
+        Args:
+            X (NDArray[np.float64]): Test inputs.
+            
+        Returns:
+            NDArray[np.float64]: the estimated propensity score for each input.
+        """
         p = self._binary_classification_estimation_model.predict_proba(X)
         p = self._reshape_proba(p)
-        p = self._binary_classification_calibration_model.predict_proba(p)
+        if self._binary_classification_calibration_model is not None:
+            p = self._binary_classification_calibration_model.predict_proba(p)
         p = np.clip(p, *self._clip_range)
         return p / (1 - p)
     

--- a/caliber/ood/propensity_score.py
+++ b/caliber/ood/propensity_score.py
@@ -1,0 +1,52 @@
+from caliber.binary_classification.base import AbstractBinaryClassificationModel
+from caliber.binary_classification.minimizing.linear_scaling.calibration.beta import BetaBinaryClassificationModel
+from xgboost import XGBClassifier
+from numpy.typing import NDArray
+import numpy as np
+
+
+class PropensityScoreEstimationModel:
+    def __init__(
+        self,
+        binary_classification_estimation_model: AbstractBinaryClassificationModel = XGBClassifier(objective='binary:logistic'),
+        binary_classification_calibration_model: AbstractBinaryClassificationModel = BetaBinaryClassificationModel(),
+        calib_frac: float = 0.5,
+        clip_range: tuple[float, float] = (0.05, 0.95),
+        seed: int = 0,
+    ) -> None:
+        self._binary_classification_estimation_model = binary_classification_estimation_model
+        self._binary_classification_calibration_model = binary_classification_calibration_model
+        self._calib_frac = calib_frac
+        self._clip_range = clip_range
+        self._rng = np.random.default_rng(seed)
+        
+    def fit(self, X: NDArray[np.float64], y: NDArray[np.int64]) -> None:
+        size = len(X)
+        train_size = int(size * (1 - self._calib_frac))
+        perm = self._rng.choice(size, size, replace=False)
+        train_perm, calib_perm = perm[:train_size], perm[train_size:]
+        X_train, X_calib = X[train_perm], X[calib_perm]
+        y_train, y_calib = y[train_perm], y[calib_perm] 
+        
+        self._binary_classification_estimation_model.fit(X_train, y_train)
+        p_calib = self._binary_classification_estimation_model.predict_proba(X_calib)
+        p_calib = self._reshape_proba(p_calib)
+        
+        self._binary_classification_calibration_model.fit(p_calib, y_calib)
+        
+    def predict(self, X: NDArray[np.float64]) -> NDArray[np.float64]:
+        p = self._binary_classification_estimation_model.predict_proba(X)
+        p = self._reshape_proba(p)
+        p = self._binary_classification_calibration_model.predict_proba(p)
+        p = np.clip(p, *self._clip_range)
+        return p / (1 - p)
+    
+    def _reshape_proba(self, p: NDArray[np.float64]) -> NDArray[np.float64]:
+        if p.ndim > 1:
+            if p.shape[1] == 2:
+                p = p[:, 1]
+            elif p.shape[1] == 1:
+                p = p.squeeze(1)
+            else:
+                raise ValueError("The binary classification estimation model does not seem to return binary class probabilities.")
+        return p

--- a/caliber/ood/propensity_score.py
+++ b/caliber/ood/propensity_score.py
@@ -22,10 +22,10 @@ class PropensityScoreEstimationModel:
         
         Args:
             binary_classification_estimation_model (_type_, optional): A binary classification model to classify inputs to source and 
-            target distributions. The model needs to include a `fit` and a `predict_proba` methods, with analogous signature as in 
-            standard Scikit-Learn binary classification models. Defaults to XGBClassifier(objective='binary:logistic').
+                target distributions. The model needs to include a `fit` and a `predict_proba` methods, with analogous signature as in 
+                standard Scikit-Learn binary classification models. Defaults to XGBClassifier(objective='binary:logistic').
             binary_classification_calibration_model (AbstractBinaryClassificationModel | None, optional): A binary classification model 
-            to calibrate the probability returned by the estimation model. Defaults to BetaBinaryClassificationModel().
+                to calibrate the probability returned by the estimation model. Defaults to BetaBinaryClassificationModel().
             calib_frac (float, optional): The fraction of the data reserved for calibration. Defaults to 0.5.
             clip_range (tuple[float, float], optional): The range to clip the propensity score within. Defaults to (0.05, 0.95).
             seed (int, optional): a random seed. Defaults to 0.

--- a/caliber/ood/propensity_score.py
+++ b/caliber/ood/propensity_score.py
@@ -1,45 +1,55 @@
-from caliber.binary_classification.base import AbstractBinaryClassificationModel
-from caliber.binary_classification.minimizing.linear_scaling.calibration.beta import BetaBinaryClassificationModel
-from xgboost import XGBClassifier
-from numpy.typing import NDArray
 import numpy as np
+from numpy.typing import NDArray
+from xgboost import XGBClassifier
+
+from caliber.binary_classification.base import AbstractBinaryClassificationModel
+from caliber.binary_classification.minimizing.linear_scaling.calibration.beta import (
+    BetaBinaryClassificationModel,
+)
 
 
 class PropensityScoreEstimationModel:
     def __init__(
         self,
-        binary_classification_estimation_model: AbstractBinaryClassificationModel = XGBClassifier(objective='binary:logistic'),
-        binary_classification_calibration_model: AbstractBinaryClassificationModel | None = BetaBinaryClassificationModel(),
+        binary_classification_estimation_model: AbstractBinaryClassificationModel = XGBClassifier(
+            objective="binary:logistic"
+        ),
+        binary_classification_calibration_model: AbstractBinaryClassificationModel
+        | None = BetaBinaryClassificationModel(),
         calib_frac: float = 0.5,
         clip_range: tuple[float, float] = (0.05, 0.95),
         seed: int = 0,
     ) -> None:
         """
-        A propensity score estimation model. Given inputs from a source and a target distribution, 
+        A propensity score estimation model. Given inputs from a source and a target distribution,
         and targets describing which distributions they belong to,
         the model fits and then calibrates the probability that the input belongs to the distribution with target label equal 1.
         Finally, it predicts the propensity score as an odds ratio, clipped to make sure it does not explode.
-        
+
         Args:
-            binary_classification_estimation_model (_type_, optional): A binary classification model to classify inputs to source and 
-                target distributions. The model needs to include a `fit` and a `predict_proba` methods, with analogous signature as in 
+            binary_classification_estimation_model (_type_, optional): A binary classification model to classify inputs to source and
+                target distributions. The model needs to include a `fit` and a `predict_proba` methods, with analogous signature as in
                 standard Scikit-Learn binary classification models. Defaults to XGBClassifier(objective='binary:logistic').
-            binary_classification_calibration_model (AbstractBinaryClassificationModel | None, optional): A binary classification model 
+            binary_classification_calibration_model (AbstractBinaryClassificationModel | None, optional): A binary classification model
                 to calibrate the probability returned by the estimation model. Defaults to BetaBinaryClassificationModel().
             calib_frac (float, optional): The fraction of the data reserved for calibration. Defaults to 0.5.
             clip_range (tuple[float, float], optional): The range to clip the propensity score within. Defaults to (0.05, 0.95).
             seed (int, optional): a random seed. Defaults to 0.
         """
-        self._binary_classification_estimation_model = binary_classification_estimation_model
-        self._binary_classification_calibration_model = binary_classification_calibration_model
+        self._binary_classification_estimation_model = (
+            binary_classification_estimation_model
+        )
+        self._binary_classification_calibration_model = (
+            binary_classification_calibration_model
+        )
         self._calib_frac = calib_frac
         self._clip_range = clip_range
         self._rng = np.random.default_rng(seed)
-        
+
     def fit(self, X: NDArray[np.float64], y: NDArray[np.int64]) -> None:
         """
         Fits the propensity score model.
-        
+
         Args:
             X (NDArray[np.float64]): Inputs from source and target distributions.
             y (NDArray[np.int64]): Binary targets describing which distribution an input belongs to.
@@ -50,23 +60,25 @@ class PropensityScoreEstimationModel:
             perm = self._rng.choice(size, size, replace=False)
             train_perm, calib_perm = perm[:train_size], perm[train_size:]
             X_train, X_calib = X[train_perm], X[calib_perm]
-            y_train, y_calib = y[train_perm], y[calib_perm] 
-            
+            y_train, y_calib = y[train_perm], y[calib_perm]
+
             self._binary_classification_estimation_model.fit(X_train, y_train)
-            p_calib = self._binary_classification_estimation_model.predict_proba(X_calib)
+            p_calib = self._binary_classification_estimation_model.predict_proba(
+                X_calib
+            )
             p_calib = self._reshape_proba(p_calib)
-            
+
             self._binary_classification_calibration_model.fit(p_calib, y_calib)
         else:
             self._binary_classification_estimation_model.fit(X, y)
-        
+
     def predict(self, X: NDArray[np.float64]) -> NDArray[np.float64]:
         """
         Predicts the propensity score.
-        
+
         Args:
             X (NDArray[np.float64]): Test inputs.
-            
+
         Returns:
             NDArray[np.float64]: the estimated propensity score for each input.
         """
@@ -76,7 +88,7 @@ class PropensityScoreEstimationModel:
             p = self._binary_classification_calibration_model.predict_proba(p)
         p = np.clip(p, *self._clip_range)
         return p / (1 - p)
-    
+
     def _reshape_proba(self, p: NDArray[np.float64]) -> NDArray[np.float64]:
         if p.ndim > 1:
             if p.shape[1] == 2:
@@ -84,5 +96,7 @@ class PropensityScoreEstimationModel:
             elif p.shape[1] == 1:
                 p = p.squeeze(1)
             else:
-                raise ValueError("The binary classification estimation model does not seem to return binary class probabilities.")
+                raise ValueError(
+                    "The binary classification estimation model does not seem to return binary class probabilities."
+                )
         return p

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "caliber"
 version = "0.1.24"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.9,<3.12"
+requires-python = ">=3.10,<3.12"
 dependencies = [
     "absolufy-imports>=0.3.1",
     "matplotlib>=3.9.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "caliber"
-version = "0.1.23"
+version = "0.1.24"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.9,<3.12"

--- a/tests/ood/test_ood_two_moons.py
+++ b/tests/ood/test_ood_two_moons.py
@@ -1,14 +1,16 @@
 import numpy as np
 import pytest
-from sklearn.neural_network import MLPClassifier
+from numpy.typing import NDArray
 
-from caliber import MahalanobisBinaryClassificationModel
+from caliber import MahalanobisBinaryClassificationModel, PropensityScoreEstimationModel
 from data import load_two_moons_data
 
 METHODS = {
     "mahalanobis_without_targets": MahalanobisBinaryClassificationModel(threshold=0.5),
     "mahalanobis_with_targets": MahalanobisBinaryClassificationModel(threshold=0.5),
 }
+
+PROPENSITY_SCORE_METHODS = {"psem": PropensityScoreEstimationModel()}
 
 train_inputs, test_inputs, train_targets, test_targets = load_two_moons_data()
 
@@ -25,8 +27,20 @@ def test_method(method_name: str) -> None:
     check_probs_preds(test_probs, test_preds)
 
 
-def check_probs_preds(probs: np.ndarray, preds: np.ndarray) -> None:
+@pytest.mark.parametrize("method_name", list(PROPENSITY_SCORE_METHODS.keys()))
+def test_propensity_score_method(method_name: str) -> None:
+    m = PROPENSITY_SCORE_METHODS[method_name]
+    m.fit(train_inputs, train_targets)
+    test_preds = m.predict(test_inputs)
+    check_propensity_score_preds(test_preds)
+
+
+def check_probs_preds(probs: NDArray[np.float64], preds: NDArray[np.float64]) -> None:
     assert probs.ndim == 1
     assert np.all(probs <= 1) and np.all(probs >= 0)
     assert preds.ndim == 1
     assert set(preds) in [{0, 1}, {0}, {1}]
+
+
+def check_propensity_score_preds(preds: NDArray[np.float64]) -> None:
+    assert preds.ndim == 1

--- a/uv.lock
+++ b/uv.lock
@@ -65,7 +65,7 @@ wheels = [
 
 [[package]]
 name = "caliber"
-version = "0.1.21"
+version = "0.1.24"
 source = { editable = "." }
 dependencies = [
     { name = "absolufy-imports" },


### PR DESCRIPTION
Takes dataset of input data points from source and target data points, where labels are binary to differentiate source against target, and fits a model to predict the propensity score.